### PR TITLE
Add boolean field filtering support

### DIFF
--- a/src-tauri/src/db/database.rs
+++ b/src-tauri/src/db/database.rs
@@ -621,6 +621,15 @@ impl Database {
                         where_clauses.push(format!("CAST({quoted} AS VARCHAR) LIKE ?"));
                         where_interpolations.push(Box::new(format!("{filter_value}%")));
                     }
+                    Some("BOOLEAN") => {
+                        // For boolean types, compare directly to TRUE or FALSE
+                        let quoted = Self::quote_identifier(column_name);
+                        match filter_value.to_lowercase().as_str() {
+                            "true" => where_clauses.push(format!("{quoted} = TRUE")),
+                            "false" => where_clauses.push(format!("{quoted} = FALSE")),
+                            _ => {} // Skip invalid boolean filter values
+                        }
+                    }
                     _ => {
                         // For VARCHAR (default), use ILIKE with substring matching
                         let quoted = Self::quote_identifier(column_name);
@@ -2468,6 +2477,68 @@ mod tests {
         assert_eq!(
             result.total, 3,
             "Min 100 + include_blank should match 100, 1000, and NULL"
+        );
+    }
+
+    #[test]
+    fn test_search_filter_by_boolean_field_true() {
+        let csv_data = b"occurrenceID,scientificName,captive\n\
+            1,Species A,true\n\
+            2,Species B,false\n\
+            3,Species C,true\n";
+
+        let fixture = TestFixture::new("boolean_filter_true", vec![csv_data]);
+        let db = Database::create_from_core_files(
+            &fixture.csv_paths,
+            &[],
+            &fixture.db_path,
+            "occurrenceID",
+        ).unwrap();
+
+        let mut filters = HashMap::new();
+        filters.insert("captive".to_string(), "true".to_string());
+        let result = db.search(10, 0, SearchParams {
+            filters,
+            ..Default::default()
+        }, None).unwrap();
+
+        assert_eq!(result.total, 2, "Filtering captive=true should return 2 records");
+        for row in &result.results {
+            assert_eq!(
+                row.get("captive").and_then(|v| v.as_bool()),
+                Some(true),
+                "All results should have captive=true"
+            );
+        }
+    }
+
+    #[test]
+    fn test_search_filter_by_boolean_field_false() {
+        let csv_data = b"occurrenceID,scientificName,captive\n\
+            1,Species A,true\n\
+            2,Species B,false\n\
+            3,Species C,true\n";
+
+        let fixture = TestFixture::new("boolean_filter_false", vec![csv_data]);
+        let db = Database::create_from_core_files(
+            &fixture.csv_paths,
+            &[],
+            &fixture.db_path,
+            "occurrenceID",
+        ).unwrap();
+
+        let mut filters = HashMap::new();
+        filters.insert("captive".to_string(), "false".to_string());
+        let result = db.search(10, 0, SearchParams {
+            filters,
+            ..Default::default()
+        }, None).unwrap();
+
+        assert_eq!(result.total, 1, "Filtering captive=false should return 1 record");
+        assert_eq!(
+            result.results[0].get("captive").and_then(|v| v.as_bool()),
+            Some(false),
+            "Result should have captive=false"
         );
     }
 }

--- a/src/lib/components/Filters.svelte
+++ b/src/lib/components/Filters.svelte
@@ -2,7 +2,10 @@
 import { Accordion } from '@skeletonlabs/skeleton-svelte';
 import { ArrowUpDown, MinusIcon, PlusIcon } from 'lucide-svelte';
 import type { SearchParams } from '$lib/utils/filterCategories';
-import { categorizeColumns } from '$lib/utils/filterCategories';
+import {
+  BOOLEAN_COLUMNS,
+  categorizeColumns,
+} from '$lib/utils/filterCategories';
 import ComboboxFilter from './ComboboxFilter.svelte';
 import MinMaxFilter from './MinMaxFilter.svelte';
 
@@ -262,6 +265,28 @@ function handleSortByChange() {
                     v,
                   )}
               />
+            {:else if BOOLEAN_COLUMNS.includes(columnName)}
+              <div class="mb-2 px-2">
+                <label class="label">
+                  <span class="label-text text-xs">{columnName}</span>
+                  <select
+                    class="select select-sm w-full"
+                    value={localParams[columnName] ? String(localParams[columnName]) : ''}
+                    onchange={(e) => {
+                      const val = (e.target as HTMLSelectElement).value;
+                      if (val) {
+                        handleFilterChange(columnName, val);
+                      } else {
+                        handleFilterClear(columnName);
+                      }
+                    }}
+                  >
+                    <option value="">Any</option>
+                    <option value="true">true</option>
+                    <option value="false">false</option>
+                  </select>
+                </label>
+              </div>
             {:else}
               <ComboboxFilter
                 {columnName}

--- a/src/lib/utils/filterCategories.ts
+++ b/src/lib/utils/filterCategories.ts
@@ -93,6 +93,17 @@ export interface SearchParams {
   institutionCode?: string;
   collectionCode?: string;
 
+  // Boolean fields
+  captive?: string;
+  hasCoordinate?: string;
+  hasGeospatialIssues?: string;
+  hasTaxonomicIssue?: string;
+  hasNonTaxonomicIssue?: string;
+  identificationCurrent?: string;
+  isInvasive?: string;
+  isSequenced?: string;
+  repatriated?: string;
+
   // Sorting (reserved field names, not filters)
   sort_by?: string;
   sort_direction?: 'ASC' | 'DESC';
@@ -176,6 +187,18 @@ const CATALOG_COLUMNS: (keyof SearchParams)[] = [
 ];
 
 const PERSON_COLUMNS: (keyof SearchParams)[] = ['recordedBy', 'identifiedBy'];
+
+export const BOOLEAN_COLUMNS: (keyof SearchParams)[] = [
+  'captive',
+  'hasCoordinate',
+  'hasGeospatialIssues',
+  'hasTaxonomicIssue',
+  'hasNonTaxonomicIssue',
+  'identificationCurrent',
+  'isInvasive',
+  'isSequenced',
+  'repatriated',
+];
 
 // Synthetic filter fields that don't exist as database columns
 const SYNTHETIC_FIELDS: (keyof SearchParams)[] = [


### PR DESCRIPTION
## Summary
This PR adds support for filtering records by boolean fields in the database search functionality. Boolean columns can now be filtered using a dropdown selector in the UI that allows users to select "true", "false", or "Any" (no filter).

## Key Changes
- **Backend (Rust)**: Added boolean field filtering logic in the database search query builder that directly compares boolean columns to TRUE/FALSE values, with case-insensitive string matching for filter input
- **Frontend (Svelte)**: Implemented a dropdown filter component for boolean columns that appears in the filter panel alongside existing filter types
- **Type definitions**: Added 9 boolean field definitions to SearchParams interface and exported a BOOLEAN_COLUMNS constant for identifying which columns should use boolean filtering
- **Tests**: Added two comprehensive test cases validating filtering by boolean fields for both true and false values

## Implementation Details
- Boolean filter values are matched case-insensitively ("true"/"false" strings) and invalid values are silently skipped
- The UI dropdown provides three options: "Any" (clears filter), "true", and "false"
- Boolean columns include: captive, hasCoordinate, hasGeospatialIssues, hasTaxonomicIssue, hasNonTaxonomicIssue, identificationCurrent, isInvasive, isSequenced, and repatriated

https://claude.ai/code/session_01PxRHnUPkPJB8mGTgjbeMgq